### PR TITLE
Add text.TableDef

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,13 @@ Text utilities.
 * `text.Pluralize()` makes a word singular or plural based on the specified count.
   Calls through to `github.com/gertd/go-pluralize` with hidden global pluralizer
   and simplified calling convention.
+* `text.AddNumericSeparators` adds separators (commas or whatever)
+  every three digits in the integer part of a number.
+* `text.FormatUSD()` invokes `text.AddNumericSeparators` and adds a dollar sign prefix.
+* `text.TableDef` defines a simple table structure that can be used to generate:
+  * a format string for the header row of the table,
+  * a divider string for use below the header or in between table sections, and
+  * a format string for the data rows of the table.
 
 ## `typeutils`
 

--- a/text/table.go
+++ b/text/table.go
@@ -1,0 +1,149 @@
+package text
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Find Unicode characters using:
+//  https://en.wikipedia.org/wiki/Box-drawing_character
+//  https://www.fileformat.info/info/unicode/char/253C/index.htm
+
+const (
+	doubleVertical                 rune = '\u2551' // '\U00E28FB8'
+	singleHorizontal                    = '\u2500'
+	singleHorizontalDoubleVertical      = '\u256B'
+	singleHorizontalSingleVertical      = '\u253C'
+	singleVertical                      = '\u2502'
+
+	newLine byte = '\n'
+	space   byte = ' '
+)
+
+// ColumnDef defines a column for the table.
+type ColumnDef struct {
+	// The width of the column in spaces.
+	Width int
+
+	// The printf format specification for row data for the column.
+	// If this is left empty a simple string format (e.g. '%4s') will be used.
+	Format string
+
+	// For columns after the first specifies that the vertical separator
+	// character before the column should be double rather than single.
+	Double bool
+}
+
+// TableDef defines a table.
+type TableDef struct {
+	// Array of ColumnDef objects that specify the columns for the table.
+	Columns []ColumnDef
+
+	// Prefix string for each row.
+	Prefix string
+
+	header, divider, row string
+}
+
+// HeaderFormat returns a printf format string for the header row.
+// This string includes a terminal newline.
+func (td *TableDef) HeaderFormat() string {
+	if td.header == "" {
+		builder := td.newBuilder()
+		var started bool
+
+		for _, column := range td.Columns {
+			if started {
+				builder.WriteByte(space)
+				if column.Double {
+					builder.WriteRune(doubleVertical)
+				} else {
+					builder.WriteRune(singleVertical)
+				}
+				builder.WriteByte(space)
+			} else {
+				started = true
+			}
+			builder.WriteString(fmt.Sprintf("%%%ds", column.Width))
+		}
+
+		builder.WriteByte(newLine)
+		td.header = builder.String()
+	}
+
+	return td.header
+}
+
+// DividerString returns a string representing a divider row.
+// No terminal newline is attached as this string is intended to be used with println.
+func (td *TableDef) DividerString() string {
+	if td.divider == "" {
+		builder := td.newBuilder()
+		var started bool
+
+		for _, column := range td.Columns {
+			if started {
+				builder.WriteRune(singleHorizontal)
+				if column.Double {
+					builder.WriteRune(singleHorizontalDoubleVertical)
+				} else {
+					builder.WriteRune(singleHorizontalSingleVertical)
+				}
+				builder.WriteRune(singleHorizontal)
+			} else {
+				started = true
+			}
+			for i := 0; i < column.Width; i++ {
+				builder.WriteRune(singleHorizontal)
+			}
+		}
+
+		td.divider = builder.String()
+	}
+
+	return td.divider
+}
+
+// RowFormat returns a printf format string for a data row.
+// This string includes a terminal newline.
+func (td *TableDef) RowFormat() string {
+	if td.row == "" {
+		builder := td.newBuilder()
+		var started bool
+
+		for _, column := range td.Columns {
+			if started {
+				builder.WriteByte(space)
+				if column.Double {
+					builder.WriteRune(doubleVertical)
+				} else {
+					builder.WriteRune(singleVertical)
+				}
+				builder.WriteByte(space)
+			} else {
+				started = true
+			}
+			if column.Format == "" {
+				builder.WriteString(fmt.Sprintf("%%%ds", column.Width))
+			} else {
+				builder.WriteString(column.Format)
+			}
+		}
+
+		builder.WriteByte(newLine)
+		td.row = builder.String()
+	}
+
+	return td.row
+}
+
+func (td *TableDef) newBuilder() *strings.Builder {
+	var builder strings.Builder
+	//var started bool
+
+	if td.Prefix != "" {
+		builder.WriteString(td.Prefix)
+	}
+
+	return &builder
+}

--- a/text/table.go
+++ b/text/table.go
@@ -32,6 +32,10 @@ type ColumnDef struct {
 	// For columns after the first specifies that the vertical separator
 	// character before the column should be double rather than single.
 	Double bool
+
+	// Specify alignment of column header and row contents if Format is not specified.
+	// By default strings alight to the right.
+	AlignLeft bool
 }
 
 // TableDef defines a table.
@@ -64,7 +68,7 @@ func (td *TableDef) HeaderFormat() string {
 			} else {
 				started = true
 			}
-			builder.WriteString(fmt.Sprintf("%%%ds", column.Width))
+			builder.WriteString(column.headerFormat())
 		}
 
 		builder.WriteByte(newLine)
@@ -123,11 +127,7 @@ func (td *TableDef) RowFormat() string {
 			} else {
 				started = true
 			}
-			if column.Format == "" {
-				builder.WriteString(fmt.Sprintf("%%%ds", column.Width))
-			} else {
-				builder.WriteString(column.Format)
-			}
+			builder.WriteString(column.dataFormat())
 		}
 
 		builder.WriteByte(newLine)
@@ -139,11 +139,26 @@ func (td *TableDef) RowFormat() string {
 
 func (td *TableDef) newBuilder() *strings.Builder {
 	var builder strings.Builder
-	//var started bool
 
 	if td.Prefix != "" {
 		builder.WriteString(td.Prefix)
 	}
 
 	return &builder
+}
+
+func (c *ColumnDef) dataFormat() string {
+	if c.Format != "" {
+		return c.Format
+	} else {
+		return c.headerFormat()
+	}
+}
+
+func (c *ColumnDef) headerFormat() string {
+	if c.AlignLeft {
+		return fmt.Sprintf("%%-%ds", c.Width)
+	} else {
+		return fmt.Sprintf("%%%ds", c.Width)
+	}
 }

--- a/text/table_test.go
+++ b/text/table_test.go
@@ -16,18 +16,9 @@ type TableTestSuite struct {
 func (suite *TableTestSuite) SetupTest() {
 	suite.tableDef = &TableDef{
 		Columns: []ColumnDef{
-			{
-				Width: 4,
-			},
-			{
-				Width:  10,
-				Format: "%10d",
-			},
-			{
-				Width:  8,
-				Format: "%8f",
-				Double: true,
-			},
+			{Width: 5, AlignLeft: true},
+			{Width: 10, Format: "%10d"},
+			{Width: 8, Format: "%8f", Double: true},
 		},
 		Prefix: "> ",
 	}
@@ -38,32 +29,23 @@ func TestExampleTestSuite(t *testing.T) {
 }
 
 func (suite *TableTestSuite) TestTable_Header() {
-	assert.Equal(suite.T(), "> %4s │ %10s ║ %8s\n", suite.tableDef.HeaderFormat())
+	assert.Equal(suite.T(), "> %-5s │ %10s ║ %8s\n", suite.tableDef.HeaderFormat())
 }
 
 func (suite *TableTestSuite) TestTable_Divider() {
-	assert.Equal(suite.T(), "> ─────┼────────────╫─────────", suite.tableDef.DividerString())
+	assert.Equal(suite.T(), "> ──────┼────────────╫─────────", suite.tableDef.DividerString())
 }
 
 func (suite *TableTestSuite) TestTable_Row() {
-	assert.Equal(suite.T(), "> %4s │ %10d ║ %8f\n", suite.tableDef.RowFormat())
+	assert.Equal(suite.T(), "> %-5s │ %10d ║ %8f\n", suite.tableDef.RowFormat())
 }
 
 func ExampleTableDef() {
 	tableDef := &TableDef{
 		Columns: []ColumnDef{
-			{
-				Width: 4,
-			},
-			{
-				Width:  10,
-				Format: "%10d",
-			},
-			{
-				Width:  8,
-				Format: "%8f",
-				Double: true,
-			},
+			{Width: 5, AlignLeft: true},
+			{Width: 10, Format: "%10d"},
+			{Width: 8, Format: "%8f", Double: true},
 		},
 		Prefix: "> ",
 	}
@@ -72,7 +54,7 @@ func ExampleTableDef() {
 	fmt.Println(tableDef.DividerString())
 	fmt.Printf(tableDef.RowFormat(), "x", 3, 4.5)
 
-	// Output: > name │      count ║    float
-	//> ─────┼────────────╫─────────
-	//>    x │          3 ║ 4.500000
+	// Output: > name  │      count ║    float
+	//> ──────┼────────────╫─────────
+	//> x     │          3 ║ 4.500000
 }

--- a/text/table_test.go
+++ b/text/table_test.go
@@ -1,0 +1,78 @@
+package text
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type TableTestSuite struct {
+	suite.Suite
+	tableDef *TableDef
+}
+
+func (suite *TableTestSuite) SetupTest() {
+	suite.tableDef = &TableDef{
+		Columns: []ColumnDef{
+			{
+				Width: 4,
+			},
+			{
+				Width:  10,
+				Format: "%10d",
+			},
+			{
+				Width:  8,
+				Format: "%8f",
+				Double: true,
+			},
+		},
+		Prefix: "> ",
+	}
+}
+
+func TestExampleTestSuite(t *testing.T) {
+	suite.Run(t, new(TableTestSuite))
+}
+
+func (suite *TableTestSuite) TestTable_Header() {
+	assert.Equal(suite.T(), "> %4s │ %10s ║ %8s\n", suite.tableDef.HeaderFormat())
+}
+
+func (suite *TableTestSuite) TestTable_Divider() {
+	assert.Equal(suite.T(), "> ─────┼────────────╫─────────", suite.tableDef.DividerString())
+}
+
+func (suite *TableTestSuite) TestTable_Row() {
+	assert.Equal(suite.T(), "> %4s │ %10d ║ %8f\n", suite.tableDef.RowFormat())
+}
+
+func ExampleTableDef() {
+	tableDef := &TableDef{
+		Columns: []ColumnDef{
+			{
+				Width: 4,
+			},
+			{
+				Width:  10,
+				Format: "%10d",
+			},
+			{
+				Width:  8,
+				Format: "%8f",
+				Double: true,
+			},
+		},
+		Prefix: "> ",
+	}
+
+	fmt.Printf(tableDef.HeaderFormat(), "name", "count", "float")
+	fmt.Println(tableDef.DividerString())
+	fmt.Printf(tableDef.RowFormat(), "x", 3, 4.5)
+
+	// Output: > name │      count ║    float
+	//> ─────┼────────────╫─────────
+	//>    x │          3 ║ 4.500000
+}


### PR DESCRIPTION
`text.TableDef` defines a simple table structure that can be used to generate:
  * a format string for the header row of the table,
  * a divider string for use below the header or in between table sections, and
  * a format string for the data rows of the table.